### PR TITLE
Update dirtshell.sh

### DIFF
--- a/dirtshell.sh
+++ b/dirtshell.sh
@@ -40,11 +40,12 @@ if [[ $? -ne 0 ]]; then
 fi
  
 # read files from a file and print to stdout
+# use -k with curl to allow insecure connections to ssl sites without certs or valid certs, often found when testing
 if [[ ! -z $cmdfile ]]; then
     if [[ -f $cmdfile ]]; then
         for i in $(cat $cmdfile); do
             echo "[+] requesting ${url}${prefix}${i}${suffix}"
-            curl -s ${cookie} ${url}${prefix}${i}${suffix}
+            curl -s -k ${cookie} ${url}${prefix}${i}${suffix}
         done
     fi
 else


### PR DESCRIPTION
Adding -k to the curl command. -k with curl to allows insecure connections to https sites without certs or valid certs.  Invalid certs are often found in lab environments and unfortunately also in the real world.